### PR TITLE
Use correct type of quotes

### DIFF
--- a/Classes/ViewHelpers/Be/Link/BeLinkViewHelper.php
+++ b/Classes/ViewHelpers/Be/Link/BeLinkViewHelper.php
@@ -80,6 +80,6 @@ class BeLinkViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBase
     protected function getModuleUrl(array $urlParameters)
     {
         $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
-        return $uriBuilder->buildUriFromRoute('web_FrpFormAnswersFormanswers',$urlParameters);
+        return $uriBuilder->buildUriFromRoute('web_FrpFormAnswersFormanswers', $urlParameters);
     }
 }


### PR DESCRIPTION
Fixes Backend Module not working if TYPO3 is in development mode, as PHP is assuming an unitizialized constants

Depending on font used it's easier to see the problem: ![image](https://user-images.githubusercontent.com/8793359/105326082-a172a300-5bcd-11eb-8ac7-09bd87e39134.png)
